### PR TITLE
 fix(#5): 로컬 DB 연결 오류 해결

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,7 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      ignoreEnvFile: true, // env_file로만 환경변수 로딩
+      //ignoreEnvFile: true, // env_file로만 환경변수 로딩
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],


### PR DESCRIPTION
closes #5 

.env 파일을 로컬에서 읽지 못함.

app.modules.ts 에서
  //ignoreEnvFile: true, // env_file로만 환경변수 로딩
 
주석 처리를 통해 해결