### PR TITLE
 fix(#11): schema의 json 배열 default 삭제

### DIFF
--- a/mysql-init/schema.sql
+++ b/mysql-init/schema.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS problems (
   description            TEXT    NOT NULL,                  -- 문제 설명
   solve_time_limit_min   INT,                               -- 풀이 제한(분)
   source                 ENUM('My','BOJ') NOT NULL DEFAULT 'My',  -- 출처(My vs BOJ)
-  categories             JSON NOT NULL DEFAULT JSON_ARRAY(),  -- 카테고리 배열
+  categories             JSON NOT NULL,  -- 카테고리 배열
   created_at             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
                           ON UPDATE CURRENT_TIMESTAMP,

--- a/src/problems/entities/problem.entity.ts
+++ b/src/problems/entities/problem.entity.ts
@@ -51,7 +51,7 @@ export class Problem {
   source: ProblemSource;
 
   // 카테고리 배열 (JSON)
-  @Column({ type: 'json', default: () => "'[]'" })
+  @Column({ type: 'json' })
   categories: string[];
 
   // 테스트케이스 (testcases.problem_id → problems.problem_id)


### PR DESCRIPTION
closes #11 

db 스키마의 problem의 categories 칼럼 = json 배열 타입 
my sql에서는 default 설정이 불가능 함 -> 삭제 조치
따라서 
problem 엔티티 또한 수정했음