### PR TITLE
fix(#17, #22): 페이지 결합 및 방 참여 로직 수정

### DIFF
--- a/mysql-init/seed.sql
+++ b/mysql-init/seed.sql
@@ -9,38 +9,17 @@ VALUES
   ('Bob',   'bob@example.com',   'hashed_password_2', NULL, NULL);
 
 -- 2) Rooms 예시 세팅 (문제 배정용)
-INSERT INTO rooms (host_id, title, invite_code, status)
+INSERT INTO rooms (title, description, max_participants, invite_code, status, creator_id, participants, problems)
 VALUES
-  (1, 'Intro to Algorithms', 'ALG1234567', 'WAITING'),
-  (2, 'Data Structures 101', 'DSC7654321', 'WAITING');
+  ('Intro to Algorithms', '알고리즘 입문', 10, 'ALG1234567', 'WAITING', 1, '[]', '[]'),
+  ('Data Structures 101', '자료구조 기초', 10, 'DSC7654321', 'WAITING', 2, '[]', '[]');
 
 -- 3) Problems 기본 문제 3개
-INSERT INTO problems (title, creator_id, execution_time_limit_ms, memory_limit_kb, description, solve_time_limit_min)
+INSERT INTO problems (title, creator_id, execution_time_limit_ms, memory_limit_kb, description, solve_time_limit_min, source, categories)
 VALUES
-  (
-    '두 수 더하기',
-    1,
-    1000,
-    65536,
-    '두 개의 정수가 주어졌을 때, 두 수의 합을 출력하는 문제입니다.',
-    10
-  ),
-  (
-    '팩토리얼 계산',
-    1,
-    2000,
-    65536,
-    'n! (1 ≤ n ≤ 20)을 계산하는 문제입니다.',
-    15
-  ),
-  (
-    '피보나치 수열',
-    2,
-    2000,
-    65536,
-    'n번째 피보나치 수(1 ≤ n ≤ 50)를 계산하는 문제입니다.',
-    15
-  );
+  ('두 수 더하기', 1, 1000, 65536, '두 개의 정수가 주어졌을 때, 두 수의 합을 출력하는 문제입니다.', 10, 'My', '["수학"]'),
+  ('팩토리얼 계산', 1, 2000, 65536, 'n! (1 ≤ n ≤ 20)을 계산하는 문제입니다.', 15, 'My', '["수학"]'),
+  ('피보나치 수열', 2, 2000, 65536, 'n번째 피보나치 수(1 ≤ n ≤ 50)를 계산하는 문제입니다.', 15, 'My', '["수학"]');
 
 -- 4) Room ↔ Problem 매핑 예시
 INSERT INTO room_problems (room_id, problem_id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-socket.io": "^11.1.3",
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.1.3",
         "axios": "^1.10.0",
@@ -28,6 +29,8 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1",
         "typeorm": "^0.3.25",
         "typeorm-naming-strategies": "^4.1.0"
       },
@@ -46,6 +49,7 @@
         "@types/node": "^22.10.7",
         "@types/passport": "^1.0.17",
         "@types/passport-jwt": "^4.0.1",
+        "@types/socket.io": "^3.0.1",
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
@@ -64,7 +68,8 @@
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.20.0"
+        "typescript-eslint": "^8.20.0",
+        "vite-plugin-monaco-editor": "^1.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2593,6 +2598,25 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.3.tgz",
+      "integrity": "sha512-jQ+ccprmh3kKolBp+bb97zoaS3vKaiyeNqyctGqV4CSG8P6mXSaaUObWxAsw6Jdgn5YQAVEBWJ6FhvF4s6QZbg==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -2901,6 +2925,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -3363,6 +3393,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3585,6 +3624,16 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/socket.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.1.tgz",
+      "integrity": "sha512-XSma2FhVD78ymvoxYV4xGXrIH/0EKQ93rR+YR0Y+Kw1xbPzLDCip/UWSejZ08FpxYeYNci/PZPQS9anrvJRqMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -5117,6 +5166,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -6274,6 +6332,125 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9625,6 +9802,14 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11217,6 +11402,173 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -12674,6 +13026,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite-plugin-monaco-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
+      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.33.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -13049,6 +13411,35 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,7 @@ import { ProblemsModule } from './problems/problems.module';
 import { RoomsModule } from './rooms/rooms.module';
 import { APP_PIPE } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+//import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { EditorModule } from './editor/editor.module';
 
 @Module({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -65,6 +65,7 @@ export class AuthController {
 
   // 3) 토큰 리프레시도 기본 가드는 스킵 → 리프레시 가드만 적용
   @Post('refresh')
+  @Public()
   @UseGuards(JwtRefreshGuard)
   @HttpCode(HttpStatus.OK)
   // 👇 req 타입을 RequestWithUser로 지정합니다.

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,6 +15,7 @@ import { LoginUserDto } from './dto/login-user.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { Request, Response } from 'express';
 import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
+import { Public } from './decorators/public.decorator';
 
 // 1. JWT 토큰에서 추출한 사용자 정보의 타입을 정의합니다.
 interface UserPayload {
@@ -36,15 +37,17 @@ interface RequestWithUser extends Request {
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  // 회원가입
+  // 1) 회원가입 공개
   @Post('signup')
+  @Public()
   @HttpCode(HttpStatus.CREATED)
   async signup(@Body() createUserDto: CreateUserDto) {
     return this.authService.signup(createUserDto);
   }
 
-  // 로그인
+  // 2) 로그인 공개
   @Post('login')
+  @Public()
   @HttpCode(HttpStatus.OK)
   async login(
     @Body() loginUserDto: LoginUserDto,
@@ -60,6 +63,7 @@ export class AuthController {
     return { accessToken };
   }
 
+  // 3) 토큰 리프레시도 기본 가드는 스킵 → 리프레시 가드만 적용
   @Post('refresh')
   @UseGuards(JwtRefreshGuard)
   @HttpCode(HttpStatus.OK)
@@ -68,8 +72,8 @@ export class AuthController {
     return this.authService.refresh(req.user);
   }
 
+  // 4) 이 아래부터는 글로벌 JwtAuthGuard가 자동 적용됨
   @Get('me')
-  @UseGuards(JwtAuthGuard)
   // 👇 req 타입을 RequestWithUser로 지정합니다.
   me(@Req() req: RequestWithUser) {
     return req.user;
@@ -77,7 +81,6 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
-  @HttpCode(HttpStatus.OK)
   // 👇 req 타입을 RequestWithUser로 지정합니다.
   async logout(
     @Req() req: RequestWithUser,

--- a/src/auth/decorators/public.decorator.ts
+++ b/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,5 @@
+// src/auth/decorators/public.decorator.ts
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ExecutionContext } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    // --- 추가된 부분: @Public() 메타데이터 확인 ---
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      // 공개(토큰 불필요) 엔드포인트라면 검증을 건너뛴다
+      return true;
+    }
+    // --- 원래 동작: JWT 토큰 검증 수행 ---
+    return super.canActivate(context);
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -21,7 +21,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       // 2. 만료된 토큰을 거부할지 여부: false로 설정하면 만료된 토큰도 허용되므로, 반드시 false로 둡니다.
       ignoreExpiration: false,
       // 3. 토큰 검증에 사용할 비밀 키
-      secretOrKey: configService.get('JWT_SECRET')!,
+      secretOrKey: configService.get<string>('JWT_SECRET')!,
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { ValidationPipe } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
+import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -12,7 +13,9 @@ async function bootstrap() {
   });
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
-  app.use(cookieParser());
+  app.use((cookieParser as unknown as () => any)());
+  const reflector = app.get(Reflector);
+  app.useGlobalGuards(new JwtAuthGuard(reflector));
   await app.listen(process.env.PORT ?? 3001);
 }
 void bootstrap();

--- a/src/problems/dtos/assign-room-problem.dto.ts
+++ b/src/problems/dtos/assign-room-problem.dto.ts
@@ -1,5 +1,8 @@
-import { IsInt } from 'class-validator';
+import { IsArray, IsInt, ArrayNotEmpty } from 'class-validator';
 
 export class AssignRoomProblemDto {
-  @IsInt() problemId: number;
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  problemIds: number[];
 }

--- a/src/problems/dtos/create-db-problem.dto.ts
+++ b/src/problems/dtos/create-db-problem.dto.ts
@@ -14,10 +14,10 @@ import { ProblemSource } from '../entities/problem.entity';
 
 class TestCaseDto {
   @IsString()
-  input: string;
+  inputTc: string;
 
   @IsString()
-  output: string;
+  outputTc: string;
 }
 
 export class CreateDbProblemDto {

--- a/src/problems/entities/room-problem.entity.ts
+++ b/src/problems/entities/room-problem.entity.ts
@@ -10,6 +10,7 @@ export class RoomProblem {
   @PrimaryColumn({ name: 'problem_id' })
   problemId: number; // FK to problems.problemId
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   @ManyToOne(() => Room, (room) => room.problems, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'room_id' })
   room: Room;

--- a/src/problems/entities/testcase.entity.ts
+++ b/src/problems/entities/testcase.entity.ts
@@ -18,13 +18,18 @@ export class Testcase {
   @JoinColumn({ name: 'problem_id' })
   problem: Problem;
 
-  @Column({ type: 'varchar', length: 255 }) inputTc: string;
-  @Column({ type: 'varchar', length: 255 }) outputTc: string;
+  @Column({ name: 'input_tc', type: 'varchar', length: 255 }) inputTc: string;
+  @Column({ name: 'output_tc', type: 'varchar', length: 255 }) outputTc: string;
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @Column({
+    name: 'created_at',
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   createdAt: Date;
 
   @Column({
+    name: 'updated_at',
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP',
     onUpdate: 'CURRENT_TIMESTAMP',

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -7,12 +7,18 @@ import {
   Param,
   Body,
   ParseIntPipe,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { ProblemsService } from './problems.service';
 import { CreateDbProblemDto } from './dtos/create-db-problem.dto';
 import { AssignRoomProblemDto } from './dtos/assign-room-problem.dto';
 import { UpdateProblemDto } from './dtos/update-problem.dto';
 import { ProblemSummaryDto } from './dtos/problem-summary.dto';
+
+interface RequestWithUser extends Request {
+  user: { id: number };
+}
 
 @Controller('api/v1')
 export class ProblemsController {
@@ -24,13 +30,15 @@ export class ProblemsController {
     return this.svc.createProblem(dto);
   }
 
-  /** 2) 방에 문제 할당 */
+  /** 2) 방에 문제 할당 (호스트만) */
   @Post('rooms/:roomId/problems')
   assignProblemToRoom(
     @Param('roomId', ParseIntPipe) roomId: number,
     @Body() dto: AssignRoomProblemDto,
+    @Req() req: RequestWithUser,
   ) {
-    return this.svc.assignProblemToRoom(roomId, dto);
+    const userId = req.user.id;
+    return this.svc.assignProblemToRoom(roomId, dto, userId);
   }
 
   /** 3) DB의 모든 문제 목록 조회 */
@@ -60,13 +68,15 @@ export class ProblemsController {
     return this.svc.getProblemDetailByRoomId(roomId, pid);
   }
 
-  /** 7) 방별 문제 정보 일부 수정 */
+  /** 7) 방별 문제 정보 일부 수정 (호스트만) */
   @Patch('rooms/:roomId/problems/:pid')
   updateProblemDetailByRoomId(
     @Param('roomId', ParseIntPipe) roomId: number,
     @Param('pid', ParseIntPipe) pid: number,
     @Body() dto: UpdateProblemDto,
+    @Req() req: RequestWithUser,
   ) {
-    return this.svc.updateProblemDetailByRoomId(roomId, pid, dto);
+    const userId = req.user.id;
+    return this.svc.updateProblemDetailByRoomId(roomId, pid, dto, userId);
   }
 }

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -38,7 +38,7 @@ export class ProblemsController {
     @Req() req: RequestWithUser,
   ) {
     const userId = req.user.id;
-    return this.svc.assignProblemToRoom(roomId, dto, userId);
+    return this.svc.assignProblemToRoom(roomId, dto.problemIds, userId);
   }
 
   /** 3) DB의 모든 문제 목록 조회 */

--- a/src/problems/problems.module.ts
+++ b/src/problems/problems.module.ts
@@ -5,9 +5,10 @@ import { ProblemsService } from './problems.service';
 import { Problem } from './entities/problem.entity';
 import { RoomProblem } from './entities/room-problem.entity';
 import { Testcase } from './entities/testcase.entity';
+import { Room } from '../rooms/entities/room.entity'; // ← 추가
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Problem, RoomProblem, Testcase])],
+  imports: [TypeOrmModule.forFeature([Problem, RoomProblem, Testcase, Room])],
   controllers: [ProblemsController],
   providers: [ProblemsService],
 })

--- a/src/problems/problems.service.ts
+++ b/src/problems/problems.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Room } from '../rooms/entities/room.entity';
 import { Problem } from './entities/problem.entity';
 import { RoomProblem } from './entities/room-problem.entity';
 import { CreateDbProblemDto } from './dtos/create-db-problem.dto';
@@ -16,6 +21,9 @@ export class ProblemsService {
 
     @InjectRepository(RoomProblem)
     private readonly roomProblemRepo: Repository<RoomProblem>,
+
+    @InjectRepository(Room)
+    private readonly roomRepo: Repository<Room>, // 방 정보 조회용
   ) {}
 
   /** 1) DB에 새 문제 생성 */
@@ -36,12 +44,19 @@ export class ProblemsService {
     return this.problemRepo.save(problem);
   }
 
-  /** 2) 방에 문제 할당 */
+  /** 2) 방에 문제 할당 (호스트만)*/
   async assignProblemToRoom(
     roomId: number,
     dto: AssignRoomProblemDto,
+    userId: number,
   ): Promise<RoomProblem> {
-    // TODO: 권한 체크, 방 존재 여부 검증 등
+    // 1) 방 존재 및 호스트 여부 확인
+    const room = await this.roomRepo.findOneBy({ roomId });
+    if (!room) throw new NotFoundException('Room not found');
+    if (room.creatorId !== userId)
+      throw new ForbiddenException('방 생성자만 문제를 할당할 수 있습니다.');
+
+    // 2) 문제-방 링크 생성
     const link = this.roomProblemRepo.create({
       roomId,
       problemId: dto.problemId,
@@ -63,14 +78,7 @@ export class ProblemsService {
     });
 
     // 엔티티 배열을 DTO 배열로 변환 (여기선 필드명이 같아 바로 반환해도 무방합니다)
-    return raws.map((p) => {
-      const dto = new ProblemSummaryDto();
-      dto.problemId = p.problemId;
-      dto.title = p.title;
-      dto.source = p.source;
-      dto.categories = p.categories;
-      return dto;
-    });
+    return raws.map((p) => Object.assign(new ProblemSummaryDto(), p));
   }
 
   /** 5) 방별 문제 목록 조회 (RoomProblem ↔ Problem join) */
@@ -95,13 +103,20 @@ export class ProblemsService {
     return link.problem;
   }
 
-  /** 7) 방별 문제 정보 일부 수정 */
+  /** 7) 방별 문제 정보 일부 수정 (호스트만)*/
   async updateProblemDetailByRoomId(
     roomId: number,
     pid: number,
     dto: UpdateProblemDto,
+    userId: number,
   ): Promise<Problem> {
-    // TODO: 권한 체크, 방 존재 여부 검증 등
+    // 1) 방 존재 및 호스트 여부 확인
+    const room = await this.roomRepo.findOneBy({ roomId });
+    if (!room) throw new NotFoundException('Room not found');
+    if (room.creatorId !== userId)
+      throw new ForbiddenException('방 생성자만 수정할 수 있습니다.');
+
+    // 2) 문제 조회·업데이트
     const problem = await this.problemRepo.findOne({
       where: { problemId: pid },
     });

--- a/src/rooms/dtos/join-room.dto.ts
+++ b/src/rooms/dtos/join-room.dto.ts
@@ -4,4 +4,8 @@ export class JoinRoomDto {
   @IsString()
   @IsNotEmpty()
   inviteCode: string;
+
+  @IsString()
+  @IsNotEmpty()
+  userName: string;
 }

--- a/src/rooms/dtos/join-room.dto.ts
+++ b/src/rooms/dtos/join-room.dto.ts
@@ -1,3 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
 export class JoinRoomDto {
+  @IsString()
+  @IsNotEmpty()
   inviteCode: string;
 }

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -26,7 +26,7 @@ export class Room {
   @Column({ name: 'max_participants' })
   maxParticipants: number;
 
-  @Column({ name: 'invite_code' })
+  @Column({ name: 'invite_code', unique: true })
   inviteCode: string;
 
   @Column({

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -41,7 +41,11 @@ export class RoomsController {
   @Post('join')
   joinRoom(@Body() joinRoomDto: JoinRoomDto, @Req() req: RequestWithUser) {
     const userId = req.user.id;
-    return this.roomsService.joinRoom(joinRoomDto.inviteCode, userId);
+    return this.roomsService.joinRoom(
+      joinRoomDto.inviteCode,
+      userId,
+      joinRoomDto.userName,
+    );
   }
 
   /**

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -32,10 +32,7 @@ export class RoomsController {
 
   /** 수업(방) 생성 */
   @Post('create')
-  create(
-    @Body() createRoomDto: CreateRoomDto,
-    @Req() req: RequestWithUser, // 헤더 대신 req.user 사용
-  ) {
+  create(@Body() createRoomDto: CreateRoomDto, @Req() req: RequestWithUser) {
     const creatorId = req.user.id;
     return this.roomsService.createRoom(createRoomDto, creatorId);
   }
@@ -43,14 +40,13 @@ export class RoomsController {
   /** 초대 코드로 수업 참가 */
   @Post('join')
   joinRoom(@Body() joinRoomDto: JoinRoomDto, @Req() req: RequestWithUser) {
-    console.log('--- Controller: /rooms/join 요청 받음 ---');
-    console.log('초대 코드:', joinRoomDto.inviteCode);
-
     const userId = req.user.id;
     return this.roomsService.joinRoom(joinRoomDto.inviteCode, userId);
   }
 
-  /** 방 정보 조회 (호스트만) */
+  /**
+   * 방 정보 + 할당된 문제들 조회 (호스트만 접근 가능)
+   */
   @Get(':roomId')
   async getRoomInfo(
     @Param('roomId') roomId: string,

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -43,6 +43,9 @@ export class RoomsController {
   /** 초대 코드로 수업 참가 */
   @Post('join')
   joinRoom(@Body() joinRoomDto: JoinRoomDto, @Req() req: RequestWithUser) {
+    console.log('--- Controller: /rooms/join 요청 받음 ---');
+    console.log('초대 코드:', joinRoomDto.inviteCode);
+
     const userId = req.user.id;
     return this.roomsService.joinRoom(joinRoomDto.inviteCode, userId);
   }

--- a/src/rooms/rooms.module.ts
+++ b/src/rooms/rooms.module.ts
@@ -4,10 +4,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { RoomsService } from './rooms.service';
 import { RoomsController } from './rooms.controller';
 import { Room } from './entities/room.entity';
+import { RoomProblem } from '../problems/entities/room-problem.entity';
+import { Problem } from '../problems/entities/problem.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Room])],
+  imports: [TypeOrmModule.forFeature([Room, RoomProblem, Problem])],
   controllers: [RoomsController],
   providers: [RoomsService],
+  exports: [RoomsService],
 })
 export class RoomsModule {}

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -46,15 +46,25 @@ export class RoomsService {
   }
 
   /** 2) 초대코드로 방 참가 */
-  async joinRoom(inviteCode: string, userId: number) {
+  async joinRoom(inviteCode: string, userId: number, userName: string) {
     const room = await this.roomRepo.findOne({ where: { inviteCode } });
     if (!room) {
       throw new BadRequestException('유효하지 않은 초대코드입니다.');
     }
 
+    if (room.creatorId === userId) {
+      throw new BadRequestException(
+        '자신이 생성한 수업에는 참여할 수 없습니다.',
+      );
+    }
+
+    if (room.participants.length >= room.maxParticipants) {
+      throw new BadRequestException('수업 정원이 가득 찼습니다.');
+    }
+
     room.participants = room.participants || [];
     if (!room.participants.some((p) => p.userId === userId)) {
-      room.participants.push({ userId, name: `사용자${userId}` });
+      room.participants.push({ userId, name: userName });
       await this.roomRepo.save(room);
     }
 


### PR DESCRIPTION
closes #17 #22 

### 채호
1. 선생님 계정으로 자신이 만든 방 참여 시 방 참여 안되게 수정
2. 방 인원 수 제한함 -> 입장 안되게 수정
3. 그리드 뷰에서 입장 시 입력 받은 이름 나오게 수정
4. 웹 소켓 추가 시 바로 재렌더링 될 수 있게 useEffect 수정 
5. 학생 입장코드 입력 시 올바른 방으로 갈 수 있게 수정

### 재준
1. 문제 생성 : 문제 db 저장 후 다시 바로 방에 할당 되게 수정
2. 문제 가져오기: 문제 db에서 다 읽어들임 -> 가져오게 수정(복수 가능)
3. 문제 생성 및 가져오기 시 재렌더링 수행되어서 즉시 문제가 들어감.