### PR TITLE
feat(#64): 수업 종료 시 학생의 리포트 페이지 연결

### DIFF
--- a/src/rooms/rooms.module.ts
+++ b/src/rooms/rooms.module.ts
@@ -8,11 +8,13 @@ import { RoomProblem } from '../problems/entities/room-problem.entity';
 import { Problem } from '../problems/entities/problem.entity';
 import { UsersModule } from '../users/users.module';
 import { Submission } from '../submissions/entities/submission.entity'; //리포트 페이지가 생긴 이후로 이게 없으면 회원가입도 로그인도 안됩니다
+import { EditorModule } from 'src/editor/editor.module'; //『안채호』
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Room, RoomProblem, Problem, Submission]), //Submission 있어야 한다. 『안채호』
     UsersModule,
+    EditorModule,
   ],
   controllers: [RoomsController],
   providers: [RoomsService],

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -12,6 +12,7 @@ import { Problem } from '../problems/entities/problem.entity';
 import { CreateRoomDto } from './dtos/create-room.dto';
 import { UsersService } from '../users/users.service';
 import { Submission } from '../submissions/entities/submission.entity';
+import { EditorGateway } from '../editor/editor.gateway';
 
 @Injectable()
 export class RoomsService {
@@ -25,6 +26,7 @@ export class RoomsService {
     @InjectRepository(Submission)
     private readonly submissionRepo: Repository<Submission>,
     private readonly usersService: UsersService,
+    private readonly editorGateway: EditorGateway,
   ) {}
 
   private generateInviteCode(): string {
@@ -156,6 +158,12 @@ export class RoomsService {
     }
 
     await this.roomRepo.save(room);
+
+    if (newStatus === RoomStatus.FINISHED) {
+      console.log(`[Backend] Emitting class:ended for room ${roomId}`);
+      const roomName = `room_${room.inviteCode}`;
+      this.editorGateway.server.to(roomName).emit('class:ended', { roomId });
+    }
     return true;
   }
 


### PR DESCRIPTION
closes #64 
선생님이 수업 종료를 누르면 백에서 웹소켓으로 수업이 종료 됬다는 신호가 갑니다. 그러면 프론트에서 신호를 받고 약속한 학생의 리포트 페이지로 넘어가게 만들었습니다.