### PR TITLE
fix(#80): 수업 나가기 시 로직 개선

### DIFF
--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -168,7 +168,7 @@ export class RoomsService {
       const roomName = `room_${room.inviteCode}`;
       this.editorGateway.server.to(roomName).emit('class:ended', { roomId });
       // 방 생성자(선생님)의 roomId null로 갱신
-      await this.usersService.updateUserRoomId(requesterId, null);
+      //await this.usersService.updateUserRoomId(requesterId, null);
     }
     return true;
   }


### PR DESCRIPTION
closes #80 
* room.service.ts 에서 updateRoomStatus에서  수업 종료 시 방 생성자(선생님)의 roomId null로 갱신 하는 부분 주석 처리

deleteRoom에서 동작하도록 개선