### PR TITLE
fix: 학생 분석 페이지 에러 메세지 추가

### DIFF
--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -449,6 +449,7 @@ export class RoomsService {
         total_tc_count: sub.total_tc_count,
         execution_time_ms: sub.execution_time_ms,
         memory_usage_kb: sub.memory_usage_kb,
+        stdout: sub.stdout,
         created_at: sub.created_at,
         user: sub.user,
         problem: sub.problem,


### PR DESCRIPTION
학생 분석 페이지에 이제 오답 시에는 에러 메세지 받아와서 보여줍니다.
선생님 페이지에서 도넛 차트도 이제는 에러 메세지를 받아서 차트로 보여줍니다.

백은 submisson 테이블에서 오류 메세지 받아오는 부분만 추가됐습니다.