### PR TITLE
fix: 학생 정답률, 문제별 정답률 로직 수정

### DIFF
--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -313,6 +313,7 @@ export class ReportsService {
         user: sub.user,
         problem: sub.problem,
       })),
+      problems, // 전체 문제 리스트 추가
       classTime: room.endTime || '00:00:00',
       classStatus: room.status,
     };
@@ -589,6 +590,7 @@ export class ReportsService {
         user: sub.user,
         problem: sub.problem,
       })),
+      problems, // 전체 문제 리스트 추가
       classTime: room.endTime || '00:00:00',
       classStatus: room.status,
     };


### PR DESCRIPTION
1. 학생 정답률, 문제별 정답률 구현됐습니다.
2. 평균 제출시간에서 한번에 제출해서 맞힌 문제로 변경하고 선생님이 제출한 경우는 제외했습니다.
3. 카테고리 분류로 바꾸고 이제 정확하게 카테고리 표현됩니다.
4. 문제 분석에서 어떻게 된건지 잘 나오고 미제출도 추가됩니다.
5. 이 모든게 마이페이지 리포트에 적용됩니다.